### PR TITLE
Added many features, compatibility with RHEL7 and clear some errors

### DIFF
--- a/lib/facter/netbackup.rb
+++ b/lib/facter/netbackup.rb
@@ -1,17 +1,30 @@
 Facter.add('netbackup_client_name') do
   setcode do
-    client_name = Facter::Util::Resolution.exec('/usr/openv/netbackup/bin/nbgetconfig CLIENT_NAME')
-    client_name.split[2]
+    if File.exist? '/usr/openv/netbackup/bin/nbgetconfig'
+      client_name = Facter::Util::Resolution.exec('/usr/openv/netbackup/bin/nbgetconfig CLIENT_NAME')
+      client_name.split[2]
+    elsif File.exist? '/usr/openv/netbackup/bp.conf'
+      client_name = Facter::Util::Resolution.exec('/bin/grep CLIENT_NAME /usr/openv/netbackup/bp.conf')
+      client_name.split[2]
+    end
   end
 end
 
+
 Facter.add('netbackup_serverlist') do
   setcode do
-    server_rows = Facter::Util::Resolution.exec('/usr/openv/netbackup/bin/nbgetconfig SERVER').split("\n")
-    servers = server_rows.map! { |x| x.split[2] }
-    servers
+    if File.exist? '/usr/openv/netbackup/bin/nbgetconfig'
+      server_rows = Facter::Util::Resolution.exec('/usr/openv/netbackup/bin/nbgetconfig SERVER').split("\n")
+      servers = server_rows.map! { |x| x.split[2] }
+      servers
+    elsif File.exist? '/usr/openv/netbackup/bp.conf'
+      server_rows = Facter::Util::Resolution.exec('/bin/grep SERVER /usr/openv/netbackup/bp.conf').split("\n")
+      servers = server_rows.map! { |x| x.split[2] }
+      servers
+    end	  
   end
 end
+
 
 # @todo Ugly code?
 Facter.add('netbackup_version') do

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -11,6 +11,7 @@ class netbackup::client (
   if versioncmp($version, $::netbackup_version) < 1 {
     notice("Installed version ${::netbackup_version} newer or equal to ${version}, not installing")
   }
+
   if versioncmp($version, $::netbackup_version) == 1 {
     notice ("Found NetBackup version: ${::netbackup_version}, have newer ${version} which I'll install using class netbackup::client::install")
     class { 'netbackup::client::install': }
@@ -38,6 +39,7 @@ class netbackup::client (
       hasrestart => false,
       hasstatus  => false,
       pattern    => 'bpcd',
+      provider   => init,
     }
   }
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -6,52 +6,17 @@ class netbackup::client (
   $mediaservers      = undef,
   $service_enabled   = true,
   $excludes          = undef,
-) {
+  $tmpinstaller      = "/tmp"
+) 
+{
 
   if versioncmp($version, $::netbackup_version) < 1 {
     notice("Installed version ${::netbackup_version} newer or equal to ${version}, not installing")
-  }
-
-  if versioncmp($version, $::netbackup_version) == 1 {
+	class { 'netbackup::client::config': }
+  } 
+  else {
     notice ("Found NetBackup version: ${::netbackup_version}, have newer ${version} which I'll install using class netbackup::client::install")
-    class { 'netbackup::client::install': }
+    class { 'netbackup::client::install': } -> class { 'netbackup::client::config': }
   }
-
-  file { '/usr/openv/netbackup':
-    ensure => directory,
-  }
-
-  file { 'bp.conf':
-    ensure  => file,
-    path    => '/usr/openv/netbackup/bp.conf',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    content => template('netbackup/bp.conf.erb'),
-    require => File['/usr/openv/netbackup'],
-  }
-
-  # Only define netbackup init service if netbackup_version fact is set
-  if $::netbackup_version != undef {
-    service { 'netbackup-client':
-      ensure     => $service_enabled,
-      name       => 'netbackup',
-      hasrestart => false,
-      hasstatus  => false,
-      pattern    => 'bpcd',
-      provider   => init,
-    }
-  }
-
-  if $excludes != undef {
-    file { 'exclude_list':
-      ensure  => file,
-      path    => '/usr/openv/netbackup/exclude_list',
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
-      content => template('netbackup/exclude_list.erb'),
-    }
-  }
-
+  
 }

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -1,0 +1,41 @@
+class netbackup::client::config (
+  $clientname        = $netbackup::client::clientname,
+  $masterserver      = $netbackup::client::masterserver,
+  $mediaservers      = $netbackup::client::mediaservers,
+  $service_enabled   = $netbackup::client::service_enabled,
+  $excludes          = $netbackup::client::excludes,
+){
+
+  file { 'bp.conf':
+    ensure  => file,
+    path    => '/usr/openv/netbackup/bp.conf',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('netbackup/bp.conf.erb'),
+  }
+
+  # Only define netbackup init service if netbackup_version fact is set
+  if $::netbackup_version != undef {
+    service { 'netbackup-client':
+      ensure     => $service_enabled,
+      name       => 'netbackup',
+      hasrestart => false,
+      hasstatus  => false,
+      pattern    => 'bpcd',
+      provider   => init,
+	  require    => File["bp.conf"]
+    }
+  }
+
+  if $excludes != undef {
+    file { 'exclude_list':
+      ensure  => file,
+      path    => '/usr/openv/netbackup/exclude_list',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('netbackup/exclude_list.erb'),
+    }
+  }
+}

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -3,10 +3,11 @@ class netbackup::client::install (
   $version            = $netbackup::client::version,
   $masterserver       = $netbackup::client::masterserver,
   $clientname         = $netbackup::client::clientname,
+  $tmpinstaller      =  $netbackup::client::tmpinstaller
 ){
 
   file { 'install_netbackup_client.expect':
-    path     => '/tmp/install_netbackup_client.expect',
+    path     => "${tmpinstaller}/install_netbackup_client.expect",
     owner    => 'root',
     group    => 'root',
     mode     => '0744',

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -19,7 +19,7 @@ class netbackup::client::install (
   }
 
   exec { 'run-netbackup-install':
-    command  => 'expect /tmp/install_netbackup_client.expect',
+    command  => "expect ${tmpinstaller}/install_netbackup_client.expect",
     path     => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     require  => [Package['expect'], File['install_netbackup_client.expect']],
     unless   => "grep ${version} /usr/openv/netbackup/bin/version",


### PR DESCRIPTION
1. Added the choice of Temporary folder for Installation, but keeping /tmp as the default (as some Systems may have noexec on /tmp)
2. Added Systemd Compatibility
3. Redesigned of client manifest to have a better dependecy cycle management …
4. Errors Fixed: change from absent to directory failed: Cannot create /usr/openv/netbackup; parent directory /usr/openv does not exist

Error: Could not start Service[netbackup-client]: Execution of '/bin/systemctl start netbackup' returned 6: Failed to start netbackup.service: Unit netbackup.service failed to load: No such file or directory.
Error: /Stage[main]/Netbackup::Client/Service[netbackup-client]/ensure: change from stopped to running failed: Could not start Service[netbackup-client]: Execution of '/bin/systemctl start netbackup' returned 6: Failed to start netbackup.service: Unit netbackup.service failed to load: No such file or directory.

Error: Facter: error while resolving custom fact "netbackup_client_name": undefined method `split' for nil:NilClass
Error: Facter: error while resolving custom fact "netbackup_serverlist": undefined method`split' for nil:NilClass
